### PR TITLE
Support lock directory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
 
         # Configure the per-system Emacs package set.
         elisp-rice = {
+          enableElispPackages = true;
           emacsPackageSet = inputs.emacs-ci.packages.${system};
           defaultEmacsPackage = inputs.emacs-ci.packages.${system}.emacs-snapshot;
         };

--- a/make-lock/flake.nix
+++ b/make-lock/flake.nix
@@ -1,0 +1,71 @@
+{
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    elisp-rice.url = "github:emacs-twist/elisp-rice";
+
+    systems.url = "github:nix-systems/default";
+
+    emacs-ci.url = "github:purcell/nix-emacs-ci";
+    twist.url = "github:emacs-twist/twist.nix";
+
+    # Inputs that should be overridden for each project.
+    rice-src.url = "github:emacs-twist/rice-config?dir=example";
+    # If your project depends only on built-in packages, you don't have to
+    # override this. Also see https://github.com/NixOS/nix/issues/9339
+    rice-lock.url = "github:emacs-twist/rice-config?dir=lock";
+
+    emacs-builtins.url = "github:emacs-twist/emacs-builtins";
+
+    registries.url = "github:emacs-twist/registries";
+    registries.inputs.melpa.follows = "melpa";
+
+    melpa.url = "github:melpa/melpa";
+    melpa.flake = false;
+  };
+
+  # Use the binary cache of emacs-ci executables.
+  nixConfig = {
+    extra-substituters = "https://emacs-ci.cachix.org";
+    extra-trusted-public-keys = "emacs-ci.cachix.org-1:B5FVOrxhXXrOL0S+tQ7USrhjMT5iOPH+QN9q0NItom4=";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-parts,
+    ...
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} ({flake-parts-lib, ...}: let
+      systems = import inputs.systems;
+    in {
+      inherit systems;
+      imports = [
+        inputs.elisp-rice.flakeModules.default
+      ];
+      elisp-rice = inputs.elisp-rice.lib.configFromInputs {
+        inherit (inputs) rice-src rice-lock registries systems;
+      };
+      perSystem = {
+        system,
+        config,
+        pkgs,
+        ...
+      }: {
+        # Configure the perSystem environment.
+        _module.args.pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            # This overlay is required to make `emacsTwist` function available
+            # in the flake-parts module.
+            inputs.twist.overlays.default
+          ];
+        };
+
+        # Configure the per-system Emacs package set.
+        elisp-rice = {
+          # Disable the packages until the lock directory is available.
+          enableElispPackages = false;
+          emacsPackageSet = inputs.emacs-ci.packages.${system};
+        };
+      };
+    });
+}

--- a/templates/default/justfile
+++ b/templates/default/justfile
@@ -35,7 +35,7 @@ eval ATTR *OPTIONS:
 # Generate a lock directory.
 lock *OPTIONS:
     mkdir -p "$(dirname {{ lock-dir }})"
-    nix run "{{ rice-config }}#{{ emacs }}-with-packages.generateLockDir" {{ common-options-without-lock }} --impure -- {{ OPTIONS }} {{ lock-dir }}
+    nix run "{{ rice-config }}?dir=make-lock#lock-with-{{ emacs }}" {{ common-options-without-lock }} --impure -- {{ OPTIONS }} {{ lock-dir }}
 
 # Enter a shell for byte-compiling individual source files
 shell-compile:


### PR DESCRIPTION
This PR adds support for persisted metadata. Now it handle dependencies containing non-ASCII characters, while avoiding IFD to generate a CI matrix for multiple platforms. The `make-lock` subflake has been restored, 

This requires https://github.com/emacs-twist/elisp-rice/pull/4, and it doesn't work until the PR is merged.


